### PR TITLE
Clean labels before stroke in Horizontal chart

### DIFF
--- a/PNChart/PNBarChartHorizontal.m
+++ b/PNChart/PNBarChartHorizontal.m
@@ -155,6 +155,7 @@
 - (void)strokeChart
 {
     [self viewCleanupForCollection:_bars];
+    [self viewCleanupForCollection:_titleLabels];
     [self updateBar];
     [self addValueLabels];
     [self performSelector:@selector(showLabelsAnimated) withObject:nil afterDelay:1];


### PR DESCRIPTION
Labels where being redraw over and over again in every screen rotation or data update. 
