### PR TITLE
Fix pie chart percentages

### DIFF
--- a/PNChart/PNPieChart.m
+++ b/PNChart/PNPieChart.m
@@ -124,7 +124,7 @@
     UILabel *descriptionLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 100, 60)];
     NSString *titleText = currentDataItem.textDescription;
     
-    int normalizedValue = (_total == 0 ? 0 : currentDataItem.value/ _total) * 100;
+    float normalizedValue = (_total == 0 ? 0 : currentDataItem.value/_total) * 100;
     NSMutableAttributedString* attributedTitleText = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%.0f%%\n", normalizedValue] attributes:@{NSForegroundColorAttributeName:currentDataItem.color,NSFontAttributeName:_fontForDetailItemNumber}];
     
     NSAttributedString* title = [[NSAttributedString alloc] initWithString:titleText attributes:@{NSForegroundColorAttributeName:_descriptionTextColor,NSFontAttributeName:_fontForDetailItemText}];


### PR DESCRIPTION
#### :tophat: What? Why?

There is an issue with the percentage value because is set as an int but formatted as a float. 
#### :ghost: GIF

![](http://i.giphy.com/xTiTnh2PC1qEjDQUrC.gif)
